### PR TITLE
Fix protein ID abbreviation in documentation

### DIFF
--- a/examples/01_prepare_core_group_from_OMA.ipynb
+++ b/examples/01_prepare_core_group_from_OMA.ipynb
@@ -281,11 +281,11 @@
     "  compatible with fDOG, e.g. `HUMAN`)\n",
     "- `NCBI_TAXID` is the NCBI taxonomy ID\n",
     "- `VERSION` is any short version string (we use `OMA2024`)\n",
-    "- `PROTEIN_ID` is the canonical protein accession (e.g. `GP3_HUMAN` for `P04406` in UniProt). Note, this ID must uniquely identify the corresponding protein sequence in the reference proteome (see 03_prepare_reference_proteome.ipynb)\n",
+    "- `PROTEIN_ID` is the canonical protein accession (e.g. `G3P_HUMAN` for `P04406` in UniProt). Note, this ID must uniquely identify the corresponding protein sequence in the reference proteome (see 03_prepare_reference_proteome.ipynb)\n",
     "\n",
     "**Example:**\n",
     "```\n",
-    ">GAPDH|HUMAN@9606@OMA2024|GP3_HUMAN\n",
+    ">GAPDH|HUMAN@9606@OMA2024|G3P_HUMAN\n",
     "MVKVGVNGFGRIGRLVTRAAFNSGKVD...\n",
     "```"
    ]


### PR DESCRIPTION
corrected GP3 to G3P from a previous edit